### PR TITLE
 fixed bug if digikey returns empty page 

### DIFF
--- a/digikey/category.py
+++ b/digikey/category.py
@@ -219,7 +219,12 @@ class Category(Searchable):
 
         for page in count(1):
             doc = super().search(param_values, {'page': page})
-            table = doc.select('table#productTable')[0]
+
+            if len(doc.select('table#productTable')) > 0:
+                table = doc.select('table#productTable')[0]
+            else:
+                break
+
             yield from self._get_parts(table, filter_qty, qty)
 
             page_text = doc.select('span.current-page')[0].text.strip()


### PR DESCRIPTION
I was playing around with the code and found that if I made the filters too tight, I would get no results, and category.py would get stuck in this for loop. Breaking the for loop if no matches are found fixes it =).